### PR TITLE
fix: gracefully close browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Gracefully close the browser process on exit @nathanfallet
+
 ### Added
 
 ### Changed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,8 +110,6 @@ async def browser(
             "Pausing after test. Send next test hotkey (default Mod+Return) to continue to next test"
         )
         NEXT_TEST_EVENT.wait()
-    await browser.stop()
-    assert browser._process_pid is None
 
 
 # signal handler for starting next test

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,7 +68,6 @@ class CreateBrowser(AbstractAsyncContextManager):
         )
 
         self.browser: zd.Browser | None = None
-        self.browser_pid: int | None = None
 
     async def __aenter__(self) -> zd.Browser:
         self.browser = await zd.start(self.config)
@@ -78,9 +77,9 @@ class CreateBrowser(AbstractAsyncContextManager):
         return self.browser
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        if self.browser is not None:
+        if self.browser is not None and self.browser._process_pid is not None:
             await self.browser.stop()
-            assert self.browser_pid is None
+            assert self.browser._process_pid is None
 
 
 @pytest.fixture

--- a/zendriver/core/browser.py
+++ b/zendriver/core/browser.py
@@ -602,6 +602,7 @@ class Browser:
             return
 
         if self.connection:
+            await self.connection.send(cdp.browser.close())
             await self.connection.aclose()
             logger.debug("closed the connection")
 


### PR DESCRIPTION
## Description

To avoid data dir corruption, I added a cdp.browser.close command before killing the process.

Linked to https://github.com/cdpdriver/kdriver/pull/33

## Pre-merge Checklist

<!--
Check each box by marking it with an x, like this: "- [x]"

Before creating your pull request, please ensure each item is completed.
-->

- [x] I have described my change in the section above.
- [x] I have ran the [`./scripts/format.sh`](https://github.com/cdpdriver/zendriver/blob/main/scripts/format.sh) and [`./scripts/lint.sh`](https://github.com/cdpdriver/zendriver/blob/main/scripts/lint.sh) scripts. My code is properly formatted and has no linting errors.
- [x] I have added my change to [CHANGELOG.md](https://github.com/cdpdriver/zendriver/blob/main/CHANGELOG.md) under the `[Unreleased]` section.
