### PR TITLE
feat: expose target info properties + remove __getattr__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Remove Connection `__getattr__` and replace it with declared `@property` @nathanfallet
+
 ### Removed
 
 ## [0.13.0] - 2025-07-24

--- a/zendriver/core/connection.py
+++ b/zendriver/core/connection.py
@@ -19,6 +19,7 @@ from typing import (
     Optional,
     TypeVar,
     Union,
+    List,
 )
 
 import websockets
@@ -185,10 +186,10 @@ class CantTouchThis(type):
 
 
 class Connection(metaclass=CantTouchThis):
-    attached: bool
     websocket: websockets.asyncio.client.ClientConnection | None = None
     _target: cdp.target.TargetInfo | None
     _current_id_mutex: asyncio.Lock = asyncio.Lock()
+    _download_behavior: List[str] | None = None
 
     def __init__(
         self,
@@ -225,6 +226,106 @@ class Connection(metaclass=CantTouchThis):
                 % (cdp.target.TargetInfo.__name__, type(target).__name__)
             )
         self._target = target
+
+    @property
+    def target_id(self) -> cdp.target.TargetID | None:
+        """
+        returns the target id of the current target.
+        if no target is set, it will return None.
+        """
+        if self.target:
+            return self.target.target_id
+        return None
+
+    @property
+    def type_(self) -> str | None:
+        """
+        returns the type of the current target.
+        if no target is set, it will return None.
+        """
+        if self.target:
+            return self.target.type_
+        return None
+
+    @property
+    def title(self) -> str | None:
+        """
+        returns the title of the current target.
+        if no target is set, it will return None.
+        """
+        if self.target:
+            return self.target.title
+        return None
+
+    @property
+    def url(self) -> str | None:
+        """
+        returns the url of the current target.
+        if no target is set, it will return None.
+        """
+        if self.target:
+            return self.target.url
+        return None
+
+    @property
+    def attached(self) -> bool | None:
+        """
+        returns True if the current target is attached, False otherwise.
+        if no target is set, it will return None.
+        """
+        if self.target:
+            return self.target.attached
+        return None
+
+    @property
+    def can_access_opener(self) -> bool | None:
+        """
+        returns True if the current target can access its opener, False otherwise.
+        if no target is set, it will return None.
+        """
+        if self.target:
+            return self.target.can_access_opener
+        return None
+
+    @property
+    def opener_id(self) -> cdp.target.TargetID | None:
+        """
+        returns the opener id of the current target.
+        if no target is set, it will return None.
+        """
+        if self.target:
+            return self.target.opener_id
+        return None
+
+    @property
+    def opener_frame_id(self) -> cdp.page.FrameId | None:
+        """
+        returns the opener frame id of the current target.
+        if no target is set, it will return None.
+        """
+        if self.target:
+            return self.target.opener_frame_id
+        return None
+
+    @property
+    def browser_context_id(self) -> cdp.browser.BrowserContextID | None:
+        """
+        returns the browser context id of the current target.
+        if no target is set, it will return None.
+        """
+        if self.target:
+            return self.target.browser_context_id
+        return None
+
+    @property
+    def subtype(self) -> str | None:
+        """
+        returns the subtype of the current target.
+        if no target is set, it will return None.
+        """
+        if self.target:
+            return self.target.subtype
+        return None
 
     @property
     def closed(self):
@@ -405,13 +506,6 @@ class Connection(metaclass=CantTouchThis):
         except AttributeError:
             # no listener created yet
             pass
-
-    def __getattr__(self, item):
-        """:meta private:"""
-        try:
-            return getattr(self.target, item)
-        except AttributeError:
-            raise
 
     async def __aenter__(self):
         """:meta private:"""

--- a/zendriver/core/tab.py
+++ b/zendriver/core/tab.py
@@ -129,7 +129,6 @@ class Tab(Connection):
     """
 
     browser: Browser | None
-    _download_behavior: List[str] | None = None
 
     def __init__(
         self,
@@ -1489,7 +1488,7 @@ class Tab(Connection):
                         if not any([_ in v for _ in ("http", "//", "/")]):
                             continue
                         abs_url = urllib.parse.urljoin(
-                            "/".join(self.url.rsplit("/")[:3]), v
+                            "/".join(self.url.rsplit("/")[:3] if self.url else []), v
                         )
                         if not abs_url.startswith(("http", "//", "ws")):
                             continue
@@ -1637,7 +1636,7 @@ class Tab(Connection):
             await self.wait()
 
         # there must be a better way...
-        origin = "/".join(self.url.split("/", 3)[:-1])
+        origin = "/".join(self.url.split("/", 3)[:-1] if self.url else [])
 
         items = await self.send(
             cdp.dom_storage.get_dom_storage_items(
@@ -1662,7 +1661,7 @@ class Tab(Connection):
         if self.target is None or not self.target.url:
             await self.wait()
         # there must be a better way...
-        origin = "/".join(self.url.split("/", 3)[:-1])
+        origin = "/".join(self.url.split("/", 3)[:-1] if self.url else [])
 
         await asyncio.gather(
             *[
@@ -1743,14 +1742,6 @@ class Tab(Connection):
             return False
 
         return other.target == self.target
-
-    def __getattr__(self, item):
-        try:
-            return getattr(self._target, item)
-        except AttributeError:
-            raise AttributeError(
-                f'"{self.__class__.__name__}" has no attribute "%s"' % item
-            )
 
     def __repr__(self):
         extra = ""


### PR DESCRIPTION
## Description

The goal of this PR is to remove `__getattr__` and have declared properties to fix mypy static type checking (we talked about it in #148 + it's a goal for #170

TODO: I will also do the same for Element, but deprecating it instead since it would be a breaking change if we remove it now (and we can remove it later for v1.0.0)

## Pre-merge Checklist

- [x] I have described my change in the section above.
- [x] I have ran the [`./scripts/format.sh`](https://github.com/cdpdriver/zendriver/blob/main/scripts/format.sh) and [`./scripts/lint.sh`](https://github.com/cdpdriver/zendriver/blob/main/scripts/lint.sh) scripts. My code is properly formatted and has no linting errors.
- [x] I have added my change to [CHANGELOG.md](https://github.com/cdpdriver/zendriver/blob/main/CHANGELOG.md) under the `[Unreleased]` section.
