### PR TITLE
feat/fix: allow reset expect and intercept

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Fix: allow reset expect and intercept @nathanfallet
+
 ### Changed
 
 ### Removed

--- a/tests/core/test_tab.py
+++ b/tests/core/test_tab.py
@@ -278,9 +278,11 @@ async def test_intercept_with_reload(browser: zd.Browser) -> None:
         ResourceType.XHR,
     ) as interception:
         await tab.get(sample_file("profile.html"))
+        await interception.response_body
         await interception.continue_request()
 
         await interception.reset()
+        await tab.reload()
         body, _ = await interception.response_body
         await interception.continue_request()
 

--- a/tests/core/test_tab.py
+++ b/tests/core/test_tab.py
@@ -218,6 +218,26 @@ async def test_expect_response(browser: zd.Browser) -> None:
         assert type(response_body) is tuple
 
 
+async def test_expect_response_with_reload(browser: zd.Browser) -> None:
+    tab = browser.main_tab
+    assert tab is not None
+
+    async with tab.expect_response(sample_file("groceries.html")) as response_info:
+        await tab.get(sample_file("groceries.html"))
+        await tab.wait_for_ready_state("complete")
+        await response_info.reset()
+        await tab.reload()
+        await tab.wait_for_ready_state("complete")
+        resp = await asyncio.wait_for(response_info.value, timeout=3)
+        assert type(resp) is zd.cdp.network.ResponseReceived
+        assert type(resp.response) is zd.cdp.network.Response
+        assert resp.request_id is not None
+
+        response_body = await response_info.response_body
+        assert response_body is not None
+        assert type(response_body) is tuple
+
+
 async def test_expect_download(browser: zd.Browser) -> None:
     tab = browser.main_tab
     assert tab is not None
@@ -240,6 +260,27 @@ async def test_intercept(browser: zd.Browser) -> None:
         ResourceType.XHR,
     ) as interception:
         await tab.get(sample_file("profile.html"))
+        body, _ = await interception.response_body
+        await interception.continue_request()
+
+        assert body is not None
+        # original_response = loads(body)
+        # assert original_response["name"] == "Zendriver"
+
+
+async def test_intercept_with_reload(browser: zd.Browser) -> None:
+    tab = browser.main_tab
+    assert tab is not None
+
+    async with tab.intercept(
+        "*/user-data.json",
+        RequestStage.RESPONSE,
+        ResourceType.XHR,
+    ) as interception:
+        await tab.get(sample_file("profile.html"))
+        await interception.continue_request()
+
+        await interception.reset()
         body, _ = await interception.response_body
         await interception.continue_request()
 

--- a/zendriver/core/intercept.py
+++ b/zendriver/core/intercept.py
@@ -51,6 +51,16 @@ class BaseFetchInterception:
         """
         Enter the context manager, adding request and response handlers.
         """
+        await self._setup()
+        return self
+
+    async def __aexit__(self, *args: typing.Any) -> None:
+        """
+        Exit the context manager, removing request and response handlers.
+        """
+        await self._teardown()
+
+    async def _setup(self) -> None:
         await self.tab.send(
             cdp.fetch.enable(
                 [
@@ -66,14 +76,18 @@ class BaseFetchInterception:
             cdp.fetch
         )  # trick to avoid another `fetch.enable` call by _register_handlers
         self.tab.add_handler(cdp.fetch.RequestPaused, self._response_handler)
-        return self
 
-    async def __aexit__(self, *args: typing.Any) -> None:
-        """
-        Exit the context manager, removing request and response handlers.
-        """
+    async def _teardown(self) -> None:
         self._remove_response_handler()
         await self.tab.send(cdp.fetch.disable())
+
+    async def reset(self) -> None:
+        """
+        Resets the internal state, allowing the expectation to be reused.
+        """
+        self.response_future = asyncio.Future()
+        await self._teardown()
+        await self._setup()
 
     @property
     async def request(self) -> cdp.network.Request:

--- a/zendriver/core/intercept.py
+++ b/zendriver/core/intercept.py
@@ -83,7 +83,7 @@ class BaseFetchInterception:
 
     async def reset(self) -> None:
         """
-        Resets the internal state, allowing the expectation to be reused.
+        Resets the internal state, allowing the interception to be reused.
         """
         self.response_future = asyncio.Future()
         await self._teardown()


### PR DESCRIPTION
## Description

Fixes #192 

I opted for a way to reset interception/expectation state, so that we can capture again after a reload.

Linked to https://github.com/cdpdriver/kdriver/pull/38

## Pre-merge Checklist

- [x] I have described my change in the section above.
- [x] I have ran the [`./scripts/format.sh`](https://github.com/cdpdriver/zendriver/blob/main/scripts/format.sh) and [`./scripts/lint.sh`](https://github.com/cdpdriver/zendriver/blob/main/scripts/lint.sh) scripts. My code is properly formatted and has no linting errors.
- [x] I have added my change to [CHANGELOG.md](https://github.com/cdpdriver/zendriver/blob/main/CHANGELOG.md) under the `[Unreleased]` section.
