### PR TITLE
In evaluate, only set serialization_options if return_by_value=False

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix for calls to `evaluate` that return JSON: only set `serialization_options` when `return_by_value=False` @thromer
+
 ### Added
 
 ### Changed

--- a/tests/sample_data/simple_json.html
+++ b/tests/sample_data/simple_json.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Simple JSON object</title>
+</head>
+<body>
+    <pre id="obj">{"a": "x", "b": 3.14159}</pre>
+</body>
+</html>

--- a/zendriver/core/tab.py
+++ b/zendriver/core/tab.py
@@ -718,11 +718,13 @@ class Tab(Connection):
         | None
         | typing.Tuple[cdp.runtime.RemoteObject, cdp.runtime.ExceptionDetails | None]
     ):
-        ser = cdp.runtime.SerializationOptions(
-            serialization="deep",
-            max_depth=10,
-            additional_parameters={"maxNodeDepth": 10, "includeShadowTree": "all"},
-        )
+        ser: cdp.runtime.SerializationOptions | None = None
+        if not return_by_value:
+            ser = cdp.runtime.SerializationOptions(
+                serialization="deep",
+                max_depth=10,
+                additional_parameters={"maxNodeDepth": 10, "includeShadowTree": "all"},
+            )
 
         remote_object, errors = await self.send(
             cdp.runtime.evaluate(


### PR DESCRIPTION
## Description

Fixes #195: now calling evaluate with return_by_value=True and an expression that evaluates to a JSON object will return the corresponding Python object.

A consequence of this change is that calling evaluate with return_by_value=True and an expression that evalutates to a non-JSON result now result in a ProtocolException. Callers may need to update their code to pass return_by_value=False.

## Pre-merge Checklist

- [x] I have described my change in the section above.
- [x] I have ran the [`./scripts/format.sh`](https://github.com/cdpdriver/zendriver/blob/main/scripts/format.sh) and [`./scripts/lint.sh`](https://github.com/cdpdriver/zendriver/blob/main/scripts/lint.sh) scripts. My code is properly formatted and has no linting errors.
- [x] I have added my change to [CHANGELOG.md](https://github.com/cdpdriver/zendriver/blob/main/CHANGELOG.md) under the `[Unreleased]` section.
