### PR TITLE
In evaluate, return the correct value when the result is falsy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix `evaluate` to return the correct value instead of None for falsy values @thromer
+
 ### Added
 
 ### Changed

--- a/tests/core/test_tab.py
+++ b/tests/core/test_tab.py
@@ -339,6 +339,17 @@ async def test_evaluate_return_by_value_simple_json(browser: zd.Browser) -> None
     ]
 
 
+async def test_evaluate_return_by_value_falsy(browser: zd.Browser) -> None:
+    tab = await browser.get(sample_file("simple_json.html"))
+    await tab.wait_for_ready_state("complete")
+
+    expr_template = "JSON.parse(document.querySelector('%s').textContent)"
+
+    assert await tab.evaluate(expr_template % "#zero") == 0
+    assert await tab.evaluate(expr_template % "#empty_array") == []
+    assert await tab.evaluate(expr_template % "#null") is None
+
+
 async def test_evaluate_stress_test_complex_objects(browser: zd.Browser) -> None:
     tab = await browser.get(sample_file("complex_object.html"))
     await tab.wait_for_ready_state("complete")

--- a/tests/sample_data/simple_json.html
+++ b/tests/sample_data/simple_json.html
@@ -2,9 +2,12 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Simple JSON object</title>
+    <title>Simple JSON objects</title>
 </head>
 <body>
     <pre id="obj">{"a": "x", "b": 3.14159}</pre>
+    <pre id="zero">0</pre>
+    <pre id="empty_array">[]</pre>
+    <pre id="null">null</pre>
 </body>
 </html>

--- a/zendriver/core/tab.py
+++ b/zendriver/core/tab.py
@@ -739,15 +739,9 @@ class Tab(Connection):
         if errors:
             raise ProtocolException(errors)
 
-        if remote_object:
-            if return_by_value:
-                if remote_object.value:
-                    return remote_object.value
-            else:
-                if remote_object.deep_serialized_value:
-                    return remote_object.deep_serialized_value.value
-
-        return remote_object, errors
+        if return_by_value:
+            return remote_object.value
+        return remote_object.deep_serialized_value.value
 
     async def js_dumps(
         self, obj_name: str, return_by_value: Optional[bool] = True

--- a/zendriver/core/tab.py
+++ b/zendriver/core/tab.py
@@ -11,7 +11,7 @@ import typing
 import urllib.parse
 import warnings
 import webbrowser
-from typing import TYPE_CHECKING, Any, List, Literal, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, List, Literal, Optional, Tuple, Union, cast
 
 from .intercept import BaseFetchInterception
 from .. import cdp
@@ -21,6 +21,7 @@ from .connection import Connection, ProtocolException
 from .expect import DownloadExpectation, RequestExpectation, ResponseExpectation
 from ..cdp.fetch import RequestStage
 from ..cdp.network import ResourceType
+from ..cdp.runtime import DeepSerializedValue
 
 
 if TYPE_CHECKING:
@@ -741,7 +742,9 @@ class Tab(Connection):
 
         if return_by_value:
             return remote_object.value
-        return remote_object.deep_serialized_value.value
+        # deep_serialized_value is guaranteed to be present when
+        # serialization_options.serialization="deep"
+        return cast(DeepSerializedValue, remote_object.deep_serialized_value).value
 
     async def js_dumps(
         self, obj_name: str, return_by_value: Optional[bool] = True


### PR DESCRIPTION
## Description

Before this change `evaluate(..., return_by_value=True)` would
incorrectly return `None` for any falsy result.

Also cleanup the `return_by_value=False` case, by removing an
unnecessary check for `remote_object.deep_serialized_value`. See the
linked issue for the rationale.

Fixes https://github.com/cdpdriver/zendriver/issues/201.

## Pre-merge Checklist

- [x] I have described my change in the section above.
- [x] I have ran the [`./scripts/format.sh`](https://github.com/cdpdriver/zendriver/blob/main/scripts/format.sh) and [`./scripts/lint.sh`](https://github.com/cdpdriver/zendriver/blob/main/scripts/lint.sh) scripts. My code is properly formatted and has no linting errors.
- [x] I have ran `uv run pytest` and ensured all tests pass.
- [x] I have added my change to [CHANGELOG.md](https://github.com/cdpdriver/zendriver/blob/main/CHANGELOG.md) under the `[Unreleased]` section.
