### PR TITLE
patch webRTC IP leaks + add disable WebGL option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+
+## [0.14.3] - 2025-09-28
+
+### Fixed
+
+- Fix WebRTC IP Leaks @ethcipher
+
+### Added
+
+- Add `disable_webRTC` and `disable_webGL` agrs to `Config` class @ethcipher
+
 ## [0.14.2] - 2025-09-09
 
 ### Fixed

--- a/zendriver/core/config.py
+++ b/zendriver/core/config.py
@@ -46,6 +46,8 @@ class Config:
         browser_connection_timeout: float = 0.25,
         browser_connection_max_tries: int = 10,
         user_agent: Optional[str] = None,
+        disable_webRTC: Optional[bool] = True,
+        disable_webGL: Optional[bool] = False,
         **kwargs: Any,
     ):
         """
@@ -106,6 +108,8 @@ class Config:
         self.host = host
         self.port = port
         self.expert = expert
+        self.disable_webRTC = disable_webRTC
+        self.disable_webGL = disable_webGL
         self._extensions: list[PathLike] = []
 
         # when using posix-ish operating system and running as root
@@ -226,6 +230,14 @@ class Config:
             args.append("--remote-debugging-host=%s" % self.host)
         if self.port:
             args.append("--remote-debugging-port=%s" % self.port)
+        if self.disable_webRTC:
+            args += [
+                "--webrtc-ip-handling-policy=disable_non_proxied_udp",
+                "--force-webrtc-ip-handling-policy",
+            ]
+        if self.disable_webGL:
+            args += ["--disable-webgl", "--disable-webgl2"]
+
         return args
 
     def add_argument(self, arg: str) -> None:


### PR DESCRIPTION
## Description

This PR adds two new config options to patch the WebRTC IP leaks:

- **`disable_webRTC` (default: `True`)**  
  Stops WebRTC from leaking your real IP address when using a proxy.  
  Behind the scenes, this sets:
- `--webrtc-ip-handling-policy=disable_non_proxied_udp`
- `--force-webrtc-ip-handling-policy`

Tested against [browserleaks.com/webrtc](https://browserleaks.com/webrtc) no leaks after the patch

1 - this before the patch or now when `disable_webRTC=False`
![photo_2025-09-28_11-09-15](https://github.com/user-attachments/assets/889ae2b7-6a9d-4341-9975-c565d0013beb)

2 - this after the patch and when `disable_webRTC=True`
![photo_2025-09-28_11-09-22](https://github.com/user-attachments/assets/002b82ff-d16b-4404-81d1-244430ee7e87)

- **`disable_webGL` (default: `False`)**  
Turns off WebGL (`--disable-webgl`, `--disable-webgl2`).  
This helps reduce fingerprinting since WebGL exposes GPU details. The Tor Browser disables WebGL for exactly this reason; the option is False. By default, you can enable it as shown in the example usage below.

### Example usage

```python
import zendriver as zd

config = zd.Config(
  disable_webRTC=True, # True by default
  disable_webGL=True   # False by default
)
```

## Pre-merge Checklist

- [x] I have described my change in the section above.
- [x] I have ran the [`./scripts/format.sh`](https://github.com/cdpdriver/zendriver/blob/main/scripts/format.sh) and [`./scripts/lint.sh`](https://github.com/cdpdriver/zendriver/blob/main/scripts/lint.sh) scripts. My code is properly formatted and has no linting errors.
- [x] I have ran `uv run pytest` and ensured all tests pass.
- [x] I have added my change to [CHANGELOG.md](https://github.com/cdpdriver/zendriver/blob/main/CHANGELOG.md) under the `[Unreleased]` section.
