### PR TITLE
fix: preserve CDP mouse button state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Correct CDP mouse pressure and button state for clicks and drags, and stop mouse movement from emitting synthetic release events.
+
 ### Added
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Correct CDP mouse pressure and button state for clicks and drags, and stop mouse movement from emitting synthetic release events.
+- Correct CDP mouse pressure and button state for clicks and drags, and stop mouse movement from emitting synthetic release events. @TheKevinWang
 
 ### Added
 

--- a/zendriver/core/element.py
+++ b/zendriver/core/element.py
@@ -561,6 +561,7 @@ class Element:
                     button=cdp.input_.MouseButton(button),
                     buttons=buttons,
                     click_count=1,
+                    force=0.5 if buttons else 0.0,
                 )
             ),
             self._tab.send(
@@ -570,8 +571,9 @@ class Element:
                     y=center[1],
                     modifiers=modifiers,
                     button=cdp.input_.MouseButton(button),
-                    buttons=buttons,
+                    buttons=0,
                     click_count=1,
+                    force=0.0,
                 )
             ),
         )
@@ -595,9 +597,6 @@ class Element:
             cdp.input_.dispatch_mouse_event("mouseMoved", x=center[0], y=center[1])
         )
         await self._tab.sleep(0.05)
-        await self._tab.send(
-            cdp.input_.dispatch_mouse_event("mouseReleased", x=center[0], y=center[1])
-        )
 
     async def mouse_drag(
         self,
@@ -646,6 +645,8 @@ class Element:
                 x=start_point[0],
                 y=start_point[1],
                 button=cdp.input_.MouseButton("left"),
+                buttons=1,
+                force=0.5,
             )
         )
 
@@ -656,6 +657,8 @@ class Element:
                     "mouseMoved",
                     x=end_point[0],
                     y=end_point[1],
+                    buttons=1,
+                    force=0.5,
                 )
             )
         elif steps > 1:
@@ -673,6 +676,8 @@ class Element:
                         "mouseMoved",
                         x=point[0],
                         y=point[1],
+                        buttons=1,
+                        force=0.5,
                     )
                 )
                 await asyncio.sleep(0)
@@ -683,6 +688,8 @@ class Element:
                 x=end_point[0],
                 y=end_point[1],
                 button=cdp.input_.MouseButton("left"),
+                buttons=0,
+                force=0.0,
             )
         )
 

--- a/zendriver/core/tab.py
+++ b/zendriver/core/tab.py
@@ -1554,7 +1554,6 @@ class Tab(Connection):
             await self.flash_point(x, y)
         else:
             await self.sleep(0.05)
-        await self.send(cdp.input_.dispatch_mouse_event("mouseReleased", x=x, y=y))
         if flash:
             await self.flash_point(x, y)
 
@@ -1588,6 +1587,7 @@ class Tab(Connection):
                 button=cdp.input_.MouseButton(button),
                 buttons=buttons,
                 click_count=1,
+                force=0.5 if buttons else 0.0,
             )
         )
 
@@ -1598,8 +1598,9 @@ class Tab(Connection):
                 y=y,
                 modifiers=modifiers,
                 button=cdp.input_.MouseButton(button),
-                buttons=buttons,
+                buttons=0,
                 click_count=1,
+                force=0.0,
             )
         )
         if flash:


### PR DESCRIPTION
Previously, releases retained the pressed `buttons` mask, drag movement omitted
the held button, and no event supplied CDP's `force` value. Consequently, page
JavaScript could see zero `PointerEvent.pressure` during a held drag. The two
movement-only helpers also emitted an unrelated release. 

The patch:

- reports `force=0.5` while a mouse button is active and `force=0` on release;
- keeps `buttons=1` on left-button drag movement and changes to `buttons=0` on
  release;
- removes synthetic releases from `Tab.mouse_move()` and
  `Element.mouse_move()`.

The `0.5` value follows the Pointer Events definition for a device that does
not support pressure: pressure is `0.5` while any button is active and `0`
otherwise. Chromium's CDP exposes this directly through the optional `force`
field on `Input.dispatchMouseEvent`.

https://github.com/cdpdriver/zendriver/issues/268