### PR TITLE
fix(browser): use /devtools/page endpoint for all target types including iframes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `404 Not Found` WebSocket connection error for `iframe` targets by routing all target connections to `/devtools/page/<target_id>` in `Browser._handle_target_update`.
+
 ### Added
 
 ### Changed

--- a/zendriver/core/browser.py
+++ b/zendriver/core/browser.py
@@ -230,7 +230,7 @@ class Browser:
                 new_target = Tab(
                     (
                         f"ws://{self.config.host}:{self.config.port}"
-                        f"/devtools/{target_info.type_ or 'page'}"  # all types are 'page' internally in chrome apparently
+                        f"/devtools/page"  # all types are 'page' internally in chrome apparently
                         f"/{target_info.target_id}"
                     ),
                     target=target_info,


### PR DESCRIPTION
## Description

### Problem
When Chrome creates targets for cross-origin iframes (Out-Of-Process Iframes / OOPIF), `Browser._handle_target_update` receives a `cdp.target.TargetCreated` event where `target_info.type_ == "iframe"`.

The WebSocket connection URL was constructed as:
```python
f"/devtools/{target_info.type_ or 'page'}"
```
This evaluated to `ws://<host>:<port>/devtools/iframe/<target_id>`. Attempting to connect to this target resulted in:
```text
websockets.exceptions.InvalidStatus: server rejected WebSocket connection: HTTP 404
```
Chrome DevTools HTTP server only accepts connections under `/devtools/page/<target_id>` for all target types (as noted in the author's comment on that line, and as already implemented in `Browser.update_targets`).

### Solution
- Changed the WebSocket URL in `Browser._handle_target_update` to always use `/devtools/page/<target_id>`.
- Allows `Tab` instances representing `iframe` targets to successfully connect via WebSocket and interact with elements inside cross-origin iframes.

Also consider exposing a property:
```python
@property
def iframes(self) -> List[tab.Tab]:
    return [item for item in self.targets if getattr(item, "type_", None) == "iframe"]
```
and searching those targets in select_all(include_frames=True) when content_document is null due to cross-origin isolation.

## Pre-merge Checklist

- [x] I have described my change in the section above.
- [x] I have ran the [`./scripts/format.sh`](https://github.com/cdpdriver/zendriver/blob/main/scripts/format.sh) and [`./scripts/lint.sh`](https://github.com/cdpdriver/zendriver/blob/main/scripts/lint.sh) scripts. My code is properly formatted and has no linting errors.
- [x] I have ran `uv run pytest` and ensured all tests pass.
- [x] I have added my change to [CHANGELOG.md](https://github.com/cdpdriver/zendriver/blob/main/CHANGELOG.md) under the `[Unreleased]` section.
